### PR TITLE
Add .gitignore for Python bytecode and __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to git ignore rules; it only affects which files are tracked, not runtime behavior.
> 
> **Overview**
> Adds a new `.gitignore` to ignore Python bytecode artifacts (`*.py[cod]`) and `__pycache__/` directories so they are not committed to the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b088812601e216b6e45261d017eda77f7bde4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->